### PR TITLE
show built in sound name on error

### DIFF
--- a/gm82audio.gml
+++ b/gm82audio.gml
@@ -40,7 +40,7 @@
                 //make sure the sound is preloaded or exported
                 sound_restore(argument0)
                 if (!__gm82audio_load_builtin(argument0)) {
-                    show_error("error preloading builtin sound: "+__gm82audio_get_error(),0)
+                    show_error("error preloading builtin " + sound_get_name(argument0) + ": "+__gm82audio_get_error(),0)
                     return 1
                 } else {
                     //we don't need it anymore

--- a/gm82audio.gml
+++ b/gm82audio.gml
@@ -40,7 +40,7 @@
                 //make sure the sound is preloaded or exported
                 sound_restore(argument0)
                 if (!__gm82audio_load_builtin(argument0)) {
-                    show_error("error preloading builtin " + sound_get_name(argument0) + ": "+__gm82audio_get_error(),0)
+                    show_error("error preloading builtin '" + sound_get_name(argument0) + "': "+__gm82audio_get_error(),0)
                     return 1
                 } else {
                     //we don't need it anymore


### PR DESCRIPTION
show built in sound name on error to make it easier to know the malformed sound
![image](https://github.com/user-attachments/assets/0c871267-cc93-4365-a6d9-eaf517422c2b)

